### PR TITLE
disable zlib to mitigate build failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,4 +25,4 @@ common --cxxopt='-std=c++17'
 
 try-import %workspace%/third_party/llvm-project/utils/bazel/.bazelrc
 
-build --macos_sdk_version=15.0 --host_macos_minimum_os=11.0 --repo_env=CC=clang --repo_env=CXX=clang++ --cxxopt=--std=c++17 --cxxopt=-Wno-return-type --cxxopt=-Wno-trigraphs --cxxopt=-Wno-implicit-const-int-float-conversion --cxxopt=-Wno-c++11-narrowing
+build --macos_sdk_version=15.0 --host_macos_minimum_os=11.0 --repo_env=CC=clang --repo_env=CXX=clang++ --cxxopt=--std=c++17 --cxxopt=-Wno-return-type --cxxopt=-Wno-trigraphs --cxxopt=-Wno-implicit-const-int-float-conversion --cxxopt=-Wno-c++11-narrowing --@llvm_zlib//:llvm_enable_zlib=false


### PR DESCRIPTION
Building JSIR failed on two environments and this fixes both of them:

* A fresh virtual machine on my M2 Pro Macbook, running Ubuntu ARM64.

* A fresh AWS EC2 c5.2xlarge instance, running Ubuntu x86_64.