### PR TITLE
Fix byte/character offset mixup in computed constants output

### DIFF
--- a/maldoca/js/ir/BUILD
+++ b/maldoca/js/ir/BUILD
@@ -337,6 +337,7 @@ cc_library(
         "//maldoca/js/driver",
         "//maldoca/js/driver:driver_cc_proto",
         "//maldoca/js/ir/conversion:utils",
+        ":utf16",
         "//maldoca/js/quickjs_babel",
         "@abseil-cpp//absl/algorithm:container",
         "@abseil-cpp//absl/log",

--- a/maldoca/js/ir/jsir_gen_lib.cc
+++ b/maldoca/js/ir/jsir_gen_lib.cc
@@ -36,6 +36,7 @@
 #include "maldoca/js/driver/driver.h"
 #include "maldoca/js/driver/driver.pb.h"
 #include "maldoca/js/ir/conversion/utils.h"
+#include "maldoca/js/ir/utf16.h"
 #include "maldoca/js/quickjs_babel/quickjs_babel.h"
 
 namespace maldoca {
@@ -69,13 +70,19 @@ std::string DumpJsirAnalysisResult(absl::string_view original_source,
       using ComputedConstant =
           JsirAnalysisResult::DynamicConstantPropagation::ComputedConstant;
 
+      // `start_offset`/`end_offset` are UTF-16 code-unit offsets produced by
+      // Babel, but `original_source` is a UTF-8 byte string. Slicing the byte
+      // string with UTF-16 offsets misreports source segments whenever the
+      // source contains non-ASCII characters, so convert to UTF-16 first.
+      const std::u16string source_u16 = Utf8ToUtf16(original_source);
+
       auto formatter = [&](std::string* out, const ComputedConstant& constant) {
         absl::StrAppendFormat(
             out, "From [%d, %d): `%s` -> `", constant.start_offset(),
             constant.end_offset(),
-            original_source.substr(
+            Utf16ToUtf8(std::u16string_view(source_u16).substr(
                 constant.start_offset(),
-                constant.end_offset() - constant.start_offset()));
+                constant.end_offset() - constant.start_offset())));
         switch (constant.value_kind_case()) {
           case ComputedConstant::kStringValue:
             absl::StrAppend(out, constant.string_value());


### PR DESCRIPTION
## Problem

When `jsir_gen` runs dynamic constant propagation on a script containing non-ASCII characters (e.g. Cyrillic text in a comment), the `Computed constants` section reports the wrong source segment.

Fixes #22.

## Root cause

`DumpJsirAnalysisResult` in `maldoca/js/ir/jsir_gen_lib.cc` formats each computed constant with `From [start, end): ...` by calling `original_source.substr(start_offset, end_offset - start_offset)`. However:

- `original_source` is the raw UTF-8 byte string.
- `start_offset` / `end_offset` are UTF-16 code-unit offsets. They come from `JsirTriviaAttr` locations, which are populated from Babel/ESTree positions (`node->start()` / `node->end()` in `ast_to_jsir.handwritten.cc`). ESTree source positions are UTF-16 code units.

Slicing a byte string with code-unit offsets diverges as soon as any non-ASCII character appears before the constant, producing the misaligned output described in the issue.

## Fix

Convert the source to UTF-16 once with the existing `Utf8ToUtf16` helper, slice it using the UTF-16 offsets, and convert the selected segment back to UTF-8 with `Utf16ToUtf8` for output. Adds the `:utf16` dependency to the `jsir_gen_lib` BUILD target.

## Testing

Manual verification of the logic: offsets recorded by the analysis are UTF-16 code-unit offsets (confirmed against `pass.cc` and the Babel position provenance), and the fix applies the existing, already-used `Utf8ToUtf16` / `Utf16ToUtf8` round-trip so byte offsets and code-unit offsets no longer get conflated.